### PR TITLE
Add Digital Asset Links to validate an Android app

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -40,6 +40,7 @@ const STYLES = ['styles/*.css'];
 const IMAGES = ['images/**/*.{svg,png}'];
 const ROOT = ['*.{txt,ico,go}', 'manifest.json', 'sw.js', 'app.yaml'];
 const HTML = ['index.html'];
+const WELL_KNOWN = ['well_known/**.*'];
 
 const BROWSERS = ['last 2 Chrome versions', 'last 2 Firefox versions',
   'last 2 Safari versions', '> 1%', 'not last 2 OperaMini versions'];
@@ -219,10 +220,14 @@ gulp.task('html', () => {
     .pipe(gulp.dest('dist/'));
 });
 
+gulp.task('wellknown', () => {
+  return gulp.src(WELL_KNOWN).pipe(gulp.dest('dist/.well-known/'));
+});
+
 gulp.task('build', (callback) => {
   runSequence(
     'clean',
-    ['styles-rev', 'scripts', 'data', 'images'],
+    ['styles-rev', 'scripts', 'data', 'images', 'wellknown'],
     ['root', 'html'],
     callback
   );

--- a/well_known/assetlinks.json
+++ b/well_known/assetlinks.json
@@ -1,0 +1,8 @@
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "org.chromium.twa.materialmoney",
+    "sha256_cert_fingerprints": ["82:04:C5:DB:19:A8:B9:8A:27:14:F0:3E:F5:23:2C:6B:B6:B9:63:10:F2:F9:CD:44:72:AA:C6:7E:09:E1:1C:47",
+      "91:45:8F:34:E3:13:E4:58:1C:12:21:7A:FD:1E:BD:5C:BE:9B:DE:2C:1E:57:DC:0D:2B:0E:91:1D:A6:36:CA:E8"]}
+}]


### PR DESCRIPTION
- Adds a `well_known` folder that contains files that should go
  under `.well-known` under dist.
- Updates the build script to copy the files from `well_known` to
  `dist/.well-known`.